### PR TITLE
Update ultimatesensor_mini_v1.yaml

### DIFF
--- a/ultimatesensor_mini_v1.yaml
+++ b/ultimatesensor_mini_v1.yaml
@@ -125,7 +125,9 @@ wifi:
   enable_rrm: true
 
 ota:
-  password: !secret ota_password
+  - platform: esphome
+    password: !secret ota_password
+  
 
 api:
   encryption:


### PR DESCRIPTION
As per version esphome version 2024.6.0 the OTA require - platform see: https://esphome.io/changelog/2024.6.0.html

updated configuration to add the platform to OTA.